### PR TITLE
Update example to show using tag differentiator

### DIFF
--- a/examples/log_files.yml.example.advanced
+++ b/examples/log_files.yml.example.advanced
@@ -8,7 +8,6 @@ files:
   - /home/**/*.log
   - /var/log/mysqld.log
   - /var/run/mysqld/mysqld-slow.log
-  
 exclude_files:
   - old
   - 200\d

--- a/examples/log_files.yml.example.advanced
+++ b/examples/log_files.yml.example.advanced
@@ -1,11 +1,14 @@
 # see README - demonstrates all optional arguments and more glob formats
 files: 
   - /var/log/httpd/access_log
+  - path: /var/log/http-staging/access_log
+    tag: staging # this changes the log name to staging, letting you differentiate between your production web access_log and staging web access_log
   - /var/log/httpd/error_log
   - /opt/misc/*.log
   - /home/**/*.log
   - /var/log/mysqld.log
   - /var/run/mysqld/mysqld-slow.log
+  
 exclude_files:
   - old
   - 200\d


### PR DESCRIPTION
I've updated the advanced example to show the use of tag, as introduced in pr #51
"Added support for specifying application name in config file and command line"
@siavashs

